### PR TITLE
HBASE-22210 Fix hbase-connectors-assembly to include every jar

### DIFF
--- a/bin/hbase-connectors
+++ b/bin/hbase-connectors
@@ -237,7 +237,7 @@ if [ "$COMMAND" = "kafkaproxy" ] ; then
   fi
 
   # add the kafka proxy jars
-  add_connector_jars_to_classpath "hbase-kafka-proxy"
+  add_connector_jars_to_classpath "lib"
 
 elif [ "$COMMAND" = "kafkaproxytest" ] ; then
   CLASS='org.apache.hadoop.hbase.kafka.DumpToStringListener'
@@ -246,7 +246,7 @@ elif [ "$COMMAND" = "kafkaproxytest" ] ; then
   fi
 
   # add the kafka proxy jars
-  add_connector_jars_to_classpath "hbase-kafka-proxy"
+  add_connector_jars_to_classpath "lib"
 
 else
   CLASS=$COMMAND

--- a/hbase-connectors-assembly/pom.xml
+++ b/hbase-connectors-assembly/pom.xml
@@ -67,7 +67,6 @@
 
               <descriptors>
                 <descriptor>src/main/assembly/hbase-connectors-bin.xml</descriptor>
-
               </descriptors>
             </configuration>
           </execution>
@@ -90,7 +89,6 @@
           </execution>
         </executions>
       </plugin>
-
 
       <!-- licensing info from our dependencies -->
       <plugin>

--- a/hbase-connectors-assembly/src/main/assembly/connector-components.xml
+++ b/hbase-connectors-assembly/src/main/assembly/connector-components.xml
@@ -36,9 +36,9 @@
       <outputDirectory>bin</outputDirectory>
       <includes>
         <include>hbase-connectors</include>
-	    <include>hbase-connectors-config.sh</include>
+        <include>hbase-connectors-config.sh</include>
         <include>hbase-connectors-daemon.sh</include>
-       </includes>
+      </includes>
       <fileMode>0755</fileMode>
       <directoryMode>0755</directoryMode>
     </fileSet>

--- a/hbase-connectors-assembly/src/main/assembly/hbase-connectors-bin.xml
+++ b/hbase-connectors-assembly/src/main/assembly/hbase-connectors-bin.xml
@@ -21,7 +21,6 @@
  * limitations under the License.
  */
 -->
-  <!--This 'all' id is not appended to the produced bundle because we do this: http://maven.apache.org/plugins/maven-assembly-plugin/faq.html#required-classifiers -->
   <id>bin</id>
   <formats>
     <format>tar.gz</format>

--- a/hbase-connectors-assembly/src/main/assembly/hbase-connectors-bin.xml
+++ b/hbase-connectors-assembly/src/main/assembly/hbase-connectors-bin.xml
@@ -22,7 +22,7 @@
  */
 -->
   <!--This 'all' id is not appended to the produced bundle because we do this: http://maven.apache.org/plugins/maven-assembly-plugin/faq.html#required-classifiers -->
-  <id>hbase-connectors-bin</id>
+  <id>bin</id>
   <formats>
     <format>tar.gz</format>
   </formats>
@@ -33,21 +33,18 @@
   <moduleSets>
     <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
-      <includes>
-	<include>org.apache.hbase.connectors:hbase-kafka-proxy</include>
-      </includes>
       <binaries>
         <unpack>false</unpack>
-        <outputDirectory>hbase-kafka-proxy</outputDirectory>
-      <dependencySets>
-        <dependencySet>
-          <excludes>
-            <exclude>org.apache.yetus:audience-annotations</exclude>
-            <exclude>org.slf4j:slf4j-api</exclude>
-            <exclude>org.slf4j:slf4j-log4j12</exclude>
-          </excludes>
-        </dependencySet>
-      </dependencySets>
+        <outputDirectory>lib</outputDirectory>
+        <dependencySets>
+          <dependencySet>
+            <excludes>
+              <exclude>org.apache.yetus:audience-annotations</exclude>
+              <exclude>org.slf4j:slf4j-api</exclude>
+              <exclude>org.slf4j:slf4j-log4j12</exclude>
+            </excludes>
+          </dependencySet>
+        </dependencySets>
       </binaries>
     </moduleSet>
  </moduleSets>


### PR DESCRIPTION
Assembly layout and name is harmonized with the main project:
* jar files are placed under lib
* final assembly name is hbase-connectors-<version>-bin.tar.gz