### PR TITLE
HBASE-22319 Fix for warning The assembly descriptor contains a filesy…

### DIFF
--- a/hbase-connectors-assembly/src/main/assembly/hbase-connectors-bin.xml
+++ b/hbase-connectors-assembly/src/main/assembly/hbase-connectors-bin.xml
@@ -53,11 +53,11 @@
   <files>
     <file>
       <source>../LICENSE.txt</source>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
     </file>
     <file>
       <source>../NOTICE.txt</source>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
     </file>
   </files>
 </assembly>


### PR DESCRIPTION
…stem-root relative reference