### PR TITLE
HBASE-22674 remove findbugs installation via apt-get because it brings in openjdk-jre and we need a jdk.

### DIFF
--- a/dev-support/Dockerfile
+++ b/dev-support/Dockerfile
@@ -22,15 +22,11 @@ FROM maven:3.6-jdk-8
 # hadolint ignore=DL3008
 RUN apt-get -q update && apt-get -q install --no-install-recommends -y \
        git \
-       bats \
-       findbugs \
        rsync \
        shellcheck \
        wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-ENV FINDBUGS_HOME /usr
 
 ###
 # Avoid out of memory errors in builds


### PR DESCRIPTION
we can work out how to properly get findbugs or spotbugs after getting precommit building.