### PR TITLE
HBASE-23348 Spark's createTable method throws an exception while the table is being split

### DIFF
--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/DefaultSource.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/DefaultSource.scala
@@ -164,7 +164,7 @@ case class HBaseRelation (
       // Initialize hBase table if necessary
       val admin = connection.getAdmin
       try {
-        if (!admin.isTableAvailable(tName)) {
+        if (!admin.tableExists(tName)) {
           val tableDesc = new HTableDescriptor(tName)
           cfs.foreach { x =>
             val cf = new HColumnDescriptor(x.getBytes())


### PR DESCRIPTION
HBaseRelation.createTable checks table existence with HBaseAdmin.isTableAvailable method in DefaultSource.scala (createTable). This is unfortunate, because it can return false while splitting, so createTable will fail. It should use tableExists.