### PR TITLE
HBASE-24088 Solve the ambiguous reference for scala 2.12

### DIFF
--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/datasources/HBaseTableScanRDD.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/datasources/HBaseTableScanRDD.scala
@@ -213,7 +213,7 @@ class HBaseTableScanRDD(relation: HBaseRelation,
     val scans = partition.scanRanges
       .map(buildScan(_, filter, columns))
     val tableResource = TableResource(relation)
-    context.addTaskCompletionListener(context => close())
+    context.addTaskCompletionListener[Unit](context => close())
     val points = partition.points
     val gIt: Iterator[Result] =  {
       if (points.isEmpty) {


### PR DESCRIPTION
When the `hbase-spark` module is compiled under the scala 2.12 environment, the following error appears in line 216 of the `org.apache.hadoop.hbase.spark.datasources.HBaseTableScanRDD` class:
```shell
[ERROR] [Error] /path/hbase-connectors/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/datasources/HBaseTableScanRDD.scala:216: ambiguous reference to overloaded definition,
both method addTaskCompletionListener in class TaskContext of type [U](f: org.apache.spark.TaskContext => U)org.apache.spark.TaskContext
and  method addTaskCompletionListener in class TaskContext of type (listener: org.apache.spark.util.TaskCompletionListener)org.apache.spark.TaskContext
match argument types (org.apache.spark.TaskContext => Unit)
```
I solve this bug by changing the origin line:
```scala
context.addTaskCompletionListener(context => close())
```
To:
```scala
context.addTaskCompletionListener[Unit](context => close())
```