### PR TITLE
[HBASE-25357] allow specifying binary row key range to pre-split regions

### DIFF
--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/DefaultSource.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/DefaultSource.scala
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hbase.spark
 
+import java.nio.charset.StandardCharsets
 import java.util
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -150,12 +151,10 @@ case class HBaseRelation (
 
   def createTable() {
     val numReg = parameters.get(HBaseTableCatalog.newTable).map(x => x.toInt).getOrElse(0)
-    val startKey =  Bytes.toBytes(
-      parameters.get(HBaseTableCatalog.regionStart)
-        .getOrElse(HBaseTableCatalog.defaultRegionStart))
-    val endKey = Bytes.toBytes(
-      parameters.get(HBaseTableCatalog.regionEnd)
-        .getOrElse(HBaseTableCatalog.defaultRegionEnd))
+    val startKey = parameters.get(HBaseTableCatalog.regionStart)
+      .getOrElse(HBaseTableCatalog.defaultRegionStart).getBytes(StandardCharsets.ISO_8859_1)
+    val endKey = parameters.get(HBaseTableCatalog.regionEnd)
+      .getOrElse(HBaseTableCatalog.defaultRegionEnd).getBytes(StandardCharsets.ISO_8859_1)
     if (numReg > 3) {
       val tName = TableName.valueOf(tableName)
       val cfs = catalog.getColumnFamilies


### PR DESCRIPTION
For example, the row key may start with a long integer, we can specify
ranges to pre-split regions:

```
import java.nio.charset.StandardCharsets;
import org.apache.hadoop.hbase.util.Bytes;

df.write()
  .format("org.apache.hadoop.hbase.spark")
  .option(HBaseTableCatalog.tableCatalog(), catalog)
  .option(HBaseTableCatalog.newTable(), 5)
  .option(HBaseTableCatalog.regionStart(), new String(Bytes.toBytes(0L), StandardCharsets.ISO_8859_1))
  .option(HBaseTableCatalog.regionEnd(), new String(Bytes.toBytes(2000000L), StandardCharsets.ISO_8859_1))
  .mode(SaveMode.Append)
  .save();
```