### PR TITLE
HBASE-25236 Run package phase on spark modules

### DIFF
--- a/dev-support/jenkins/hbase-personality.sh
+++ b/dev-support/jenkins/hbase-personality.sh
@@ -44,11 +44,10 @@ function personality_modules
     MODULES=(.)
   fi
 
-  # If we'll end up needing a plugin to run on the hbase-spark or
-  # hbase-spark-it modules, then we need to ensure a 'package' phase runs.
+  # If we'll end up needing a plugin to run on the spark
+  # modules, then we need to ensure a 'package' phase runs.
   if [[ "${MODULES[*]}" =~ \. ]] || \
-     [[ "${MODULES[*]}" =~ "hbase-spark " ]] || \
-     [[ "${MODULES[*]}" =~ "hbase-spark-it" ]]; then
+     [[ "${MODULES[*]}" =~ "spark" ]]; then
     extra="${extra} package"
   fi
 


### PR DESCRIPTION
The previously used check does not work when a change is made in the parent 'spark' module so the precommit job fails because the generated classes are missing when executing test-compile. With the 'spark' regex check it matches all spark modules in the hbase-connectors repository.

https://ci-hadoop.apache.org/job/HBase/job/HBase-Connectors-PreCommit/job/PR-61/2/artifact/yetus-precommit-check/output/branch-compile-spark.txt