### PR TITLE
HBASE-25326 Allow running and building hbase-connectors with Apache Spark 3.0

### DIFF
--- a/spark/README.md
+++ b/spark/README.md
@@ -26,4 +26,11 @@ To generate an artifact for a different [spark version](https://mvnrepository.co
 $ mvn -Dspark.version=2.2.2 -Dscala.version=2.11.7 -Dscala.binary.version=2.11 clean install
 ```
 
-See above linked spark version to match spark version and supported scala version.
+---
+To build the connector with Spark 3.0, compile it with scala 2.12.
+Additional configurations that you can customize are the Spark version, HBase version, and Hadoop version.
+Example:
+
+```
+$ mvn -Dspark.version=3.0.1 -Dscala.version=2.12.10 -Dscala.binary.version=2.12 -Dhbase.version=2.2.4 -Dhadoop.profile=3.0 -Dhadoop-three.version=3.2.0 -DskipTests clean package
+```

--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/datasources/Utils.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/datasources/Utils.scala
@@ -56,7 +56,7 @@ object Utils {
         case DoubleType => Bytes.toDouble(src, offset)
         case DateType => new Date(Bytes.toLong(src, offset))
         case TimestampType => new Timestamp(Bytes.toLong(src, offset))
-        case StringType => UTF8String.fromBytes(src, offset, length)
+        case StringType => Bytes.toString(src, offset, length)
         case BinaryType =>
           val newArray = new Array[Byte](length)
           System.arraycopy(src, offset, newArray, 0, length)


### PR DESCRIPTION
Currently hbase-spark connector only works with Spark 2.x. Apache Spark 3.0 has been relesead in June 2020.
This addresses the changes needed to run the connector with Spark 3.0 and also to be able to compile the connector using Spark 3.0 as a dependency.
This has been manually tested with Apache Spark 3.0.1 and HBase 2.2.4.