### PR TITLE
HBASE-24356 Move hbase-connectors to hbase-thirdparty-4.0.1

### DIFF
--- a/kafka/hbase-kafka-proxy/src/main/java/org/apache/hadoop/hbase/kafka/KafkaTableForBridge.java
+++ b/kafka/hbase-kafka-proxy/src/main/java/org/apache/hadoop/hbase/kafka/KafkaTableForBridge.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.RegionLocator;
 import org.apache.hadoop.hbase.client.Row;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptor;
@@ -198,6 +199,11 @@ public class KafkaTableForBridge implements Table {
 
   @Override
   public TableDescriptor getDescriptor() throws IOException {
+    return null;
+  }
+
+  @Override
+  public RegionLocator getRegionLocator() {
     return null;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,17 +129,17 @@
     <compileSource>1.8</compileSource>
     <java.min.version>${compileSource}</java.min.version>
     <maven.min.version>3.5.0</maven.min.version>
-    <hbase.version>2.2.2</hbase.version>
+    <hbase.version>2.4.9</hbase.version>
     <exec.maven.version>1.6.0</exec.maven.version>
     <audience-annotations.version>0.5.0</audience-annotations.version>
     <junit.version>4.12</junit.version>
-    <hbase-thirdparty.version>2.2.1</hbase-thirdparty.version>
-    <hadoop-two.version>2.8.5</hadoop-two.version>
-    <hadoop-three.version>3.0.3</hadoop-three.version>
+    <hbase-thirdparty.version>4.0.1</hbase-thirdparty.version>
+    <hadoop-two.version>2.10.0</hadoop-two.version>
+    <hadoop-three.version>3.1.2</hadoop-three.version>
     <hadoop.version>${hadoop-two.version}</hadoop.version>
     <slf4j.version>1.7.25</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <checkstyle.version>8.18</checkstyle.version>
+    <checkstyle.version>8.28</checkstyle.version>
     <maven.checkstyle.version>3.1.0</maven.checkstyle.version>
     <surefire.version>3.0.0-M4</surefire.version>
     <enforcer.version>3.0.0-M3</enforcer.version>
@@ -153,7 +153,7 @@
     <commons-lang3.version>3.6</commons-lang3.version>
     <!--This property is for hadoops netty. HBase netty
          comes in via hbase-thirdparty hbase-shaded-netty-->
-    <netty.hadoop.version>3.6.2.Final</netty.hadoop.version>
+    <netty.hadoop.version>3.10.6.Final</netty.hadoop.version>
     <os.maven.version>1.6.1</os.maven.version>
     <glassfish.el.version>3.0.1-b08</glassfish.el.version>
     <compat.module>hbase-hadoop2-compat</compat.module>

--- a/spark/hbase-spark/src/test/java/org/apache/hadoop/hbase/spark/TestJavaHBaseContext.java
+++ b/spark/hbase-spark/src/test/java/org/apache/hadoop/hbase/spark/TestJavaHBaseContext.java
@@ -95,8 +95,8 @@ public class TestJavaHBaseContext implements Serializable {
 
     LOG.info("starting minicluster");
 
-    TEST_UTIL.startMiniZKCluster();
-    TEST_UTIL.startMiniHBaseCluster(1, 1);
+    //TEST_UTIL.startMiniZKCluster();
+    TEST_UTIL.startMiniCluster();
 
     LOG.info(" - minicluster started");
   }
@@ -104,8 +104,8 @@ public class TestJavaHBaseContext implements Serializable {
   @AfterClass
   public static void tearDownAfterClass() throws Exception {
     LOG.info("shuting down minicluster");
-    TEST_UTIL.shutdownMiniHBaseCluster();
-    TEST_UTIL.shutdownMiniZKCluster();
+    //TEST_UTIL.shutdownMiniHBaseCluster();
+    TEST_UTIL.shutdownMiniCluster();
     LOG.info(" - minicluster shut down");
     TEST_UTIL.cleanupTestDir();
 

--- a/spark/hbase-spark/src/test/scala/org/apache/hadoop/hbase/spark/BulkLoadSuite.scala
+++ b/spark/hbase-spark/src/test/scala/org/apache/hadoop/hbase/spark/BulkLoadSuite.scala
@@ -65,6 +65,15 @@ BeforeAndAfterEach with BeforeAndAfterAll  with Logging {
     sc.stop()
   }
 
+  override def beforeEach() {
+    try {
+      TEST_UTIL.deleteTable(TableName.valueOf(tableName))
+    } catch {
+      case e: Exception =>
+        logInfo(" - no table " + tableName + " found")
+    }
+  }
+
   test("Wide Row Bulk Load: Test multi family and multi column tests " +
     "with all default HFile Configs.") {
     val config = TEST_UTIL.getConfiguration
@@ -391,7 +400,7 @@ BeforeAndAfterEach with BeforeAndAfterAll  with Logging {
     for ( i <- 0 until f1FileList.length) {
       val reader = HFile.createReader(fs, f1FileList(i).getPath,
         new CacheConfig(config), true, config)
-      assert(reader.getCompressionAlgorithm.getName.equals("gz"))
+      assert(reader.getFileContext.getCompression.getName.equals("gz"))
       assert(reader.getDataBlockEncoding.name().equals("PREFIX"))
     }
 
@@ -401,7 +410,7 @@ BeforeAndAfterEach with BeforeAndAfterAll  with Logging {
     for ( i <- 0 until f2FileList.length) {
       val reader = HFile.createReader(fs, f2FileList(i).getPath,
         new CacheConfig(config), true, config)
-      assert(reader.getCompressionAlgorithm.getName.equals("none"))
+      assert(reader.getFileContext.getCompression.getName.equals("none"))
       assert(reader.getDataBlockEncoding.name().equals("NONE"))
     }
 
@@ -870,7 +879,7 @@ BeforeAndAfterEach with BeforeAndAfterAll  with Logging {
     for ( i <- 0 until f1FileList.length) {
       val reader = HFile.createReader(fs, f1FileList(i).getPath,
         new CacheConfig(config), true, config)
-      assert(reader.getCompressionAlgorithm.getName.equals("gz"))
+      assert(reader.getFileContext.getCompression.getName.equals("gz"))
       assert(reader.getDataBlockEncoding.name().equals("PREFIX"))
     }
 
@@ -880,7 +889,7 @@ BeforeAndAfterEach with BeforeAndAfterAll  with Logging {
     for ( i <- 0 until f2FileList.length) {
       val reader = HFile.createReader(fs, f2FileList(i).getPath,
         new CacheConfig(config), true, config)
-      assert(reader.getCompressionAlgorithm.getName.equals("none"))
+      assert(reader.getFileContext.getCompression.getName.equals("none"))
       assert(reader.getDataBlockEncoding.name().equals("NONE"))
     }
 

--- a/spark/hbase-spark/src/test/scala/org/apache/hadoop/hbase/spark/HBaseRDDFunctionsSuite.scala
+++ b/spark/hbase-spark/src/test/scala/org/apache/hadoop/hbase/spark/HBaseRDDFunctionsSuite.scala
@@ -55,7 +55,7 @@ BeforeAndAfterEach with BeforeAndAfterAll with Logging {
     TEST_UTIL.deleteTable(TableName.valueOf(tableName))
     logInfo("shuting down minicluster")
     TEST_UTIL.shutdownMiniCluster()
-
+    TEST_UTIL.cleanupTestDir
     sc.stop()
   }
 

--- a/spark/hbase-spark/src/test/scala/org/apache/hadoop/hbase/spark/PartitionFilterSuite.scala
+++ b/spark/hbase-spark/src/test/scala/org/apache/hadoop/hbase/spark/PartitionFilterSuite.scala
@@ -80,7 +80,7 @@ class PartitionFilterSuite extends FunSuite with
   override def afterAll() {
     logInfo("shutting down minicluster")
     TEST_UTIL.shutdownMiniCluster()
-
+    TEST_UTIL.cleanupTestDir
     sc.stop()
   }
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -44,9 +44,8 @@
 
   <properties>
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
-    <hbase-thirdparty.version>2.1.0</hbase-thirdparty.version>
     <jackson.version>2.9.10</jackson.version>
-    <spark.version>2.4.0</spark.version>
+    <spark.version>2.4.8</spark.version>
     <!-- The following version is in sync with Spark's choice
          Please take caution when this version is modified -->
     <scala.version>2.11.12</scala.version>


### PR DESCRIPTION
- upgrade spark version to 2.4.8
- upgrade hbase version to 2.4.9
- upgrade hadoop2 version to 2.10.0
- upgrade hadoop3 version to 3.1.2
- upgrade checkstyle to 8.28
- update related client APIs after switching to 2.4.9