### PR TITLE
HBASE-26863 fix incorrect rowkey pushdown

### DIFF
--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/DefaultSource.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/DefaultSource.scala
@@ -593,11 +593,11 @@ class ScanRange(var upperBound:Array[Byte], var isUpperBoundEqualTo:Boolean,
 
     isLowerBoundEqualTo = if (lowerBoundCompare == 0)
       isLowerBoundEqualTo && other.isLowerBoundEqualTo
-    else isLowerBoundEqualTo
+    else if (lowerBoundCompare < 0) other.isLowerBoundEqualTo else isLowerBoundEqualTo
 
     isUpperBoundEqualTo = if (upperBoundCompare == 0)
       isUpperBoundEqualTo && other.isUpperBoundEqualTo
-    else isUpperBoundEqualTo
+    else if (upperBoundCompare < 0) isUpperBoundEqualTo else other.isUpperBoundEqualTo
   }
 
   /**
@@ -643,7 +643,6 @@ class ScanRange(var upperBound:Array[Byte], var isUpperBoundEqualTo:Boolean,
    * @return      True is overlap false is not overlap
    */
   def getOverLapScanRange(other:ScanRange): ScanRange = {
-
     var leftRange:ScanRange = null
     var rightRange:ScanRange = null
 
@@ -659,14 +658,9 @@ class ScanRange(var upperBound:Array[Byte], var isUpperBoundEqualTo:Boolean,
     }
 
     if (hasOverlap(leftRange, rightRange)) {
-      // Find the upper bound and lower bound
-      if (compareRange(leftRange.upperBound, rightRange.upperBound) >= 0) {
-        new ScanRange(rightRange.upperBound, rightRange.isUpperBoundEqualTo,
-          rightRange.lowerBound, rightRange.isLowerBoundEqualTo)
-      } else {
-        new ScanRange(leftRange.upperBound, leftRange.isUpperBoundEqualTo,
-          rightRange.lowerBound, rightRange.isLowerBoundEqualTo)
-      }
+      val result = new ScanRange(upperBound, isUpperBoundEqualTo, lowerBound, isLowerBoundEqualTo)
+      result.mergeIntersect(other)
+      result
     } else {
       null
     }

--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/DefaultSource.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/DefaultSource.scala
@@ -593,11 +593,13 @@ class ScanRange(var upperBound:Array[Byte], var isUpperBoundEqualTo:Boolean,
 
     isLowerBoundEqualTo = if (lowerBoundCompare == 0)
       isLowerBoundEqualTo && other.isLowerBoundEqualTo
-    else if (lowerBoundCompare < 0) other.isLowerBoundEqualTo else isLowerBoundEqualTo
+    else if (lowerBoundCompare < 0) other.isLowerBoundEqualTo
+    else isLowerBoundEqualTo
 
     isUpperBoundEqualTo = if (upperBoundCompare == 0)
       isUpperBoundEqualTo && other.isUpperBoundEqualTo
-    else if (upperBoundCompare < 0) isUpperBoundEqualTo else other.isUpperBoundEqualTo
+    else if (upperBoundCompare < 0) isUpperBoundEqualTo
+    else other.isUpperBoundEqualTo
   }
 
   /**


### PR DESCRIPTION
This PR fixes an incorrect rowkey pushdown caused by miscalculation of overlapping scan ranges, which occurs when spark sql optimizer generates pushdown filters in such an order that a scan range that comes later overshadows the previous scan range.