### PR TITLE
HBASE-27630: hbase-spark bulkload stage directory limited to hdfs only

### DIFF
--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/HBaseContext.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/HBaseContext.scala
@@ -656,7 +656,7 @@ class HBaseContext(@transient val sc: SparkContext,
         hbaseForeachPartition(this, (it, conn) => {
 
           val conf = broadcastedConf.value.value
-          val fs = FileSystem.get(conf)
+          val fs = new Path(stagingDir).getFileSystem(conf)
           val writerMap = new mutable.HashMap[ByteArrayWrapper, WriterLength]
           var previousRow:Array[Byte] = HConstants.EMPTY_BYTE_ARRAY
           var rollOverRequested = false
@@ -791,7 +791,7 @@ class HBaseContext(@transient val sc: SparkContext,
         hbaseForeachPartition(this, (it, conn) => {
 
           val conf = broadcastedConf.value.value
-          val fs = FileSystem.get(conf)
+          val fs = new Path(stagingDir).getFileSystem(conf)
           val writerMap = new mutable.HashMap[ByteArrayWrapper, WriterLength]
           var previousRow:Array[Byte] = HConstants.EMPTY_BYTE_ARRAY
           var rollOverRequested = false
@@ -973,7 +973,7 @@ class HBaseContext(@transient val sc: SparkContext,
     val wl = writerMap.getOrElseUpdate(new ByteArrayWrapper(family), {
       val familyDir = new Path(stagingDir, Bytes.toString(family))
 
-      fs.mkdirs(familyDir)
+      familyDir.getFileSystem(conf).mkdirs(familyDir);
 
       val loc:HRegionLocation = {
         try {


### PR DESCRIPTION
The reason for the problem was the usage of the default FileSystem instances for creating and using staging stuff. Now we use the staging path to obtain the FileSystem instance, so it should work correctly for any different from the hdfs schema.
The test uses a local filesystem and doesn't load files to the table due to limitations:
1. HBase minicluster uses hdfs only, and there is no way to specify a custom hbase.rootdir for that. So the load would not work because the staging dir is on a different filesystem
2. I tried to get hadoop-aws mock implementation working for an external filesystem, but that would require making the tests for this module published first

Both those two bullets can be addressed in separate jiras if required. 