### PR TITLE
HBASE-27658: Add max live time limit for cached connections

### DIFF
--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/datasources/HBaseSparkConf.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/datasources/HBaseSparkConf.scala
@@ -59,4 +59,6 @@ object HBaseSparkConf{
   val MAX_VERSIONS = "hbase.spark.query.maxVersions"
   /** Delayed time to close hbase-spark connection when no reference to this connection, in milliseconds. */
   val DEFAULT_CONNECTION_CLOSE_DELAY = 10 * 60 * 1000
+  /** The maximum time to keep the cached connection alive, in milliseconds. */
+  val DEFAULT_CONNECTION_MAX_LIFE_TIME = 24 * 3600 * 1000
 }


### PR DESCRIPTION
Add max live time limit for cached connections to avoid token expiration for long active connections