### PR TITLE
HBASE-28152. Replace scala.util.parsing.json with org.json4s.jackson

### DIFF
--- a/spark/hbase-spark/pom.xml
+++ b/spark/hbase-spark/pom.xml
@@ -56,12 +56,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
-      <version>${scala-parser-combinators.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>

--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/datasources/HBaseTableCatalog.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/datasources/HBaseTableCatalog.scala
@@ -253,7 +253,7 @@ object HBaseTableCatalog {
     val tableMeta = map \ table
     val nSpace = (tableMeta \ nameSpace).extractOrElse("default")
     val tName = (tableMeta \ tableName).extract[String]
-    val cIter = (map \ columns).extract[Map[String, Map[String,String]]]
+    val cIter = (map \ columns).extract[Map[String, Map[String, String]]]
     val schemaMap = mutable.HashMap.empty[String, Field]
     cIter.foreach {
       case (name, column) =>

--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/datasources/HBaseTableCatalog.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/datasources/HBaseTableCatalog.scala
@@ -22,8 +22,10 @@ import org.apache.hadoop.hbase.spark.{Logging, SchemaConverters}
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.spark.sql.types._
 import org.apache.yetus.audience.InterfaceAudience
+import org.json4s.DefaultFormats
+import org.json4s.Formats
+import org.json4s.jackson.JsonMethods
 import scala.collection.mutable
-import scala.util.parsing.json.JSON
 
 // The definition of each column cell, which may be composite type
 // TODO: add avro support
@@ -246,11 +248,12 @@ object HBaseTableCatalog {
     val parameters = convert(params)
     //  println(jString)
     val jString = parameters(tableCatalog)
-    val map = JSON.parseFull(jString).get.asInstanceOf[Map[String, _]]
-    val tableMeta = map.get(table).get.asInstanceOf[Map[String, _]]
-    val nSpace = tableMeta.get(nameSpace).getOrElse("default").asInstanceOf[String]
-    val tName = tableMeta.get(tableName).get.asInstanceOf[String]
-    val cIter = map.get(columns).get.asInstanceOf[Map[String, Map[String, String]]].toIterator
+    implicit val formats: Formats = DefaultFormats
+    val map = JsonMethods.parse(jString)
+    val tableMeta = map \ table
+    val nSpace = (tableMeta \ nameSpace).extractOrElse("default")
+    val tName = (tableMeta \ tableName).extract[String]
+    val cIter = (map \ columns).extract[Map[String, Map[String,String]]]
     val schemaMap = mutable.HashMap.empty[String, Field]
     cIter.foreach {
       case (name, column) =>
@@ -272,7 +275,7 @@ object HBaseTableCatalog {
           len)
         schemaMap.+=((name, f))
     }
-    val rKey = RowKey(map.get(rowKey).get.asInstanceOf[String])
+    val rKey = RowKey((map \ rowKey).extract[String])
     HBaseTableCatalog(nSpace, tName, rKey, SchemaMap(schemaMap), parameters)
   }
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -49,7 +49,6 @@
          Please take caution when this version is modified -->
     <scala.version>2.12.15</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <scala-parser-combinators.version>1.1.2</scala-parser-combinators.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/HBASE-28137 to support Spark 3.4 the scala-parser-combinators was added as direct dependency to HBase Spark Connector. This was needed as Spark 3.4 is not using scala-parser-combinators and it is not inherited as transitive dependency.

But this solution has a disadvantage. As the HBase Spark Connector assembly jar does not include any 3rd party libraries the scala-parser-combinators must be added to the spark classpath for HBase Spark Connector to work. A much better solution is to replace scala.util.parsing.json with org.json4s.jackson which is used by Spark core, see https://github.com/apache/spark/blob/branch-3.4/core/pom.xml#L279-L280.