### PR TITLE
HBASE-28606 Support for build on mac M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -933,5 +933,18 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <!-- Use Mac x64 version of protoc for Apple Silicon (aarch64) Macs -->
+      <id>osx-aarch64</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <os.detected.classifier>osx-x86_64</os.detected.classifier>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This change will allow hbase spark connector to compile on mac M1.