### PR TITLE
HBASE-28790 hbase-connectors fails to build with hbase 2.6.0

### DIFF
--- a/kafka/hbase-kafka-proxy/src/main/java/org/apache/hadoop/hbase/kafka/KafkaBridgeConnection.java
+++ b/kafka/hbase-kafka-proxy/src/main/java/org/apache/hadoop/hbase/kafka/KafkaBridgeConnection.java
@@ -187,6 +187,14 @@ public class KafkaBridgeConnection implements Connection {
         return null;
       }
 
+      /**
+       * This method was added in HBASE-27657. We donot add @Override to allow code to compile with
+       * versions of hbase both having and not having HBASE-27657
+       **/
+      public TableBuilder setRequestAttribute(String key, byte[] value) {
+        return null;
+      }
+
       @Override
       public Table build() {
         return new KafkaTableForBridge(tn, passedInConfiguration, routingRules, producer,


### PR DESCRIPTION
- Add missing method setRequestAttribute added in HBASE-27657